### PR TITLE
feat: integrate PEFT into fine-tuning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -158,4 +158,5 @@ dependencies:
     - torchsummary==1.5.1
     - traitlets==5.0.5
     - wcwidth==0.2.5
+    - peft
 prefix: /home/jjp/anaconda3/envs/pytorch1.01


### PR DESCRIPTION
## Summary
- integrate optional PEFT LoRA adapters into fine-tuning pipeline
- allow checkpoint loading with non-strict state dict to accommodate adapters
- add `peft` as dependency

## Testing
- `python -m py_compile finetune.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7c3fea58832c9ff560ee3ec54e2d