### PR TITLE
feat: integrate PEFT into fine-tuning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -158,4 +158,5 @@ dependencies:
     - torchsummary==1.5.1
     - traitlets==5.0.5
     - wcwidth==0.2.5
+    - peft
 prefix: /home/jjp/anaconda3/envs/pytorch1.01

--- a/finetune.py
+++ b/finetune.py
@@ -11,6 +11,12 @@ import datasets
 import viz
 import modules.Unet_common as common
 import warnings
+try:
+    from peft import LoraConfig, TaskType, get_peft_model
+    PEFT_AVAILABLE = True
+except Exception:
+    PEFT_AVAILABLE = False
+    print("PEFT library not found. Proceeding without parameter-efficient layers.")
 
 warnings.filterwarnings("ignore")
 
@@ -60,7 +66,8 @@ def computePSNR(origin, pred):
 def load(name):
     state_dicts = torch.load(name)
     network_state_dict = {k: v for k, v in state_dicts['net'].items() if 'tmp_var' not in k}
-    net.load_state_dict(network_state_dict)
+    # Allow missing keys when PEFT adapters add new parameters
+    net.load_state_dict(network_state_dict, strict=False)
     try:
         optim.load_state_dict(state_dicts['opt'])
     except Exception:
@@ -73,6 +80,33 @@ def load(name):
 net = Model()
 net.cuda()
 init_model(net)
+
+# Wrap model with PEFT adapters if available
+if PEFT_AVAILABLE:
+    # Collect unique convolution layer names for LoRA targeting
+    conv_module_names = {
+        name.split(".")[-1]
+        for name, module in net.named_modules()
+        if isinstance(module, torch.nn.Conv2d)
+    }
+
+    if conv_module_names:
+        lora_config = LoraConfig(
+            r=8,
+            lora_alpha=16,
+            lora_dropout=0.1,
+            target_modules=sorted(conv_module_names),
+            task_type=TaskType.FEATURE_EXTRACTION,
+        )
+        net = get_peft_model(net, lora_config)
+        # Display number of trainable parameters for verification
+        try:
+            net.print_trainable_parameters()
+        except Exception:
+            pass
+    else:
+        print("No convolutional modules found for LoRA; skipping PEFT wrapping.")
+
 net = torch.nn.DataParallel(net, device_ids=c.device_ids)
 para = get_parameter_number(net)
 print(para)


### PR DESCRIPTION
## Summary
- integrate optional PEFT LoRA adapters into fine-tuning pipeline
- allow checkpoint loading with non-strict state dict to accommodate adapters
- add `peft` as dependency
- automatically detect convolutional modules for LoRA to avoid missing target errors

## Testing
- `python -m py_compile finetune.py`


------
https://chatgpt.com/codex/tasks/task_e_688d7c3fea58832c9ff560ee3ec54e2d