### PR TITLE
Add PSNR metrics and logging to finetune

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -6,6 +6,10 @@ import math
 import numpy as np
 from model import *
 import config as c
+
+# Suppress verbose Visualizer output for cleaner console logging
+c.silent = True
+
 from tensorboardX import SummaryWriter
 import datasets
 import viz
@@ -106,9 +110,10 @@ log_csv_path = os.path.join(save_dir, 'training_log.csv')
 
 # 로그 저장용 리스트
 train_losses = []
-psnr_s_list = []
+psnr_r_list = []
 psnr_c_list = []
 epochs = []
+lr_list = []
 
 try:
     writer = SummaryWriter(comment='finetune', filename_suffix='steg')
@@ -173,7 +178,7 @@ try:
         #################
         if i_epoch % c.val_freq == 0:
             with torch.no_grad():
-                psnr_s = []
+                psnr_r = []
                 psnr_c = []
                 net.eval()
                 for cover, secret in datasets.testloader:
@@ -211,26 +216,32 @@ try:
                     steg = steg.cpu().numpy().squeeze() * 255
                     np.clip(steg, 0, 255)
                     psnr_temp = computePSNR(secret_rev, secret)
-                    psnr_s.append(psnr_temp)
+                    psnr_r.append(psnr_temp)
                     psnr_temp_c = computePSNR(cover, steg)
                     psnr_c.append(psnr_temp_c)
 
-                writer.add_scalars('PSNR_S', {'average psnr': np.mean(psnr_s)}, i_epoch)
+                writer.add_scalars('PSNR_R', {'average psnr': np.mean(psnr_r)}, i_epoch)
                 writer.add_scalars('PSNR_C', {'average psnr': np.mean(psnr_c)}, i_epoch)
         else:
             # validation하지 않은 epoch에도 리스트를 맞추기 위해 이전 값 복사
-            if len(psnr_s_list) > 0 and len(psnr_c_list) > 0:
-                psnr_s = [psnr_s_list[-1]]
+            if len(psnr_r_list) > 0 and len(psnr_c_list) > 0:
+                psnr_r = [psnr_r_list[-1]]
                 psnr_c = [psnr_c_list[-1]]
             else:
-                psnr_s = [0]
+                psnr_r = [0]
                 psnr_c = [0]
 
         # 로그 저장
         train_losses.append(epoch_losses[0])
-        psnr_s_list.append(np.mean(psnr_s))
+        psnr_r_list.append(np.mean(psnr_r))
         psnr_c_list.append(np.mean(psnr_c))
         epochs.append(i_epoch)
+        lr_list.append(optim.param_groups[0]['lr'])
+
+        current_lr = optim.param_groups[0]['lr']
+        print(
+            f"Epoch {i_epoch:03d} | Loss: {epoch_losses[0]:.6f} | LR: {current_lr:.6e} | PSNR_r: {np.mean(psnr_r):.4f} | PSNR_c: {np.mean(psnr_c):.4f}"
+        )
 
         # loss 그래프 실시간 시각화
         viz.show_loss(epoch_losses)
@@ -240,8 +251,9 @@ try:
         df = pd.DataFrame({
             'epoch': epochs,
             'train_loss': train_losses,
-            'psnr_s': psnr_s_list,
-            'psnr_c': psnr_c_list
+            'psnr_r': psnr_r_list,
+            'psnr_c': psnr_c_list,
+            'lr': lr_list
         })
         df.to_csv(log_csv_path, index=False)
 
@@ -268,12 +280,12 @@ try:
     plt.close()
 
     plt.figure()
-    plt.plot(epochs, psnr_s_list, label='PSNR_S', color='red')
+    plt.plot(epochs, psnr_r_list, label='PSNR_R', color='red')
     plt.xlabel('Epoch')
-    plt.ylabel('PSNR_S')
-    plt.title('PSNR_S Curve')
+    plt.ylabel('PSNR_R')
+    plt.title('PSNR_R Curve')
     plt.legend()
-    plt.savefig(os.path.join(save_dir, 'psnr_s_curve.png'))
+    plt.savefig(os.path.join(save_dir, 'psnr_r_curve.png'))
     plt.close()
 
     plt.figure()
@@ -283,6 +295,15 @@ try:
     plt.title('PSNR_C Curve')
     plt.legend()
     plt.savefig(os.path.join(save_dir, 'psnr_c_curve.png'))
+    plt.close()
+
+    plt.figure()
+    plt.plot(epochs, lr_list, label='Learning Rate', color='green')
+    plt.xlabel('Epoch')
+    plt.ylabel('LR')
+    plt.title('Learning Rate Curve')
+    plt.legend()
+    plt.savefig(os.path.join(save_dir, 'lr_curve.png'))
     plt.close()
 
 except Exception:

--- a/viz.py
+++ b/viz.py
@@ -32,10 +32,14 @@ class Visualizer:
 
             self.config_str += "==="*30 + "\n"
 
-            print(self.config_str)
-            print(header)
+            if not c.silent:
+                print(self.config_str)
+                print(header)
 
     def update_losses(self, losses, *args):
+        if c.silent:
+            return
+
         print('\r', '    '*20, end='')
         line = '\r%.3i' % (self.counter)
         for l in losses:


### PR DESCRIPTION
## Summary
- Print PSNR for cover and recovered images alongside loss and LR each epoch
- Persist LR, PSNR_c and PSNR_r values to CSV and plot them to images
- Silence visualizer output so console logs only show per-epoch metrics

## Testing
- `python -m py_compile finetune.py viz.py`


------
https://chatgpt.com/codex/tasks/task_e_688f6eb931f0832ca1a9eca40bd549bc