### PR TITLE
Add PSNR metrics and logging to finetune

### DIFF
--- a/viz.py
+++ b/viz.py
@@ -32,10 +32,14 @@ class Visualizer:
 
             self.config_str += "==="*30 + "\n"
 
-            print(self.config_str)
-            print(header)
+            if not c.silent:
+                print(self.config_str)
+                print(header)
 
     def update_losses(self, losses, *args):
+        if c.silent:
+            return
+
         print('\r', '    '*20, end='')
         line = '\r%.3i' % (self.counter)
         for l in losses:


### PR DESCRIPTION
## Summary
- Print PSNR for cover and recovered images alongside loss and LR each epoch
- Persist LR, PSNR_c and PSNR_r values to CSV and plot them to images
- Silence visualizer output so console logs only show per-epoch metrics
- Always validate so PSNR metrics are non-zero

## Testing
- `python -m py_compile finetune.py viz.py`


------
https://chatgpt.com/codex/tasks/task_e_688f6eb931f0832ca1a9eca40bd549bc