### PR TITLE
Fix circular import preventing FP32 evaluation

### DIFF
--- a/hinet.py
+++ b/hinet.py
@@ -1,4 +1,21 @@
-from model import *
+"""Core HiNet architecture.
+
+This module defines the :class:`Hinet` network used throughout the
+project.  The original implementation imported everything from
+``model.py`` in order to gain access to ``torch.nn`` as ``nn``.  However,
+``model.py`` itself imports ``Hinet`` from this file, which leads to a
+classic circular import problem.  When ``evaluate_FP32_model.py`` tried
+to import :mod:`hinet`, Python encountered this cycle and raised
+``ImportError: cannot import name 'Hinet' from partially initialized
+module 'hinet'``.
+
+To break this cycle we remove the wildcard import from ``model.py`` and
+explicitly import ``torch.nn`` here.  This ensures the module is
+self‑contained and can be imported without initializing ``model.py``
+first.
+"""
+
+import torch.nn as nn
 from invblock import INV_block
 
 


### PR DESCRIPTION
## Summary
- decouple `hinet` from `model` to resolve circular import
- add context and direct `torch.nn` import in `hinet.py`

## Testing
- `python evaluate_FP32_model.py --model ./model/model.pt` *(fails: ValueError: num_samples should be a positive integer value, but got num_samples=0)*

------
https://chatgpt.com/codex/tasks/task_e_6894b2a58b00832c97e23ff865084297